### PR TITLE
ClusterConfiguration.DNS.Type field has been removed

### DIFF
--- a/setup/kubeadm/multi-node-installation-containerd.md
+++ b/setup/kubeadm/multi-node-installation-containerd.md
@@ -299,8 +299,6 @@ apiServer:
 apiVersion: kubeadm.k8s.io/v1beta3
 certificatesDir: /etc/kubernetes/pki
 clusterName: kubernetes
-dns:
-  type: CoreDNS
 etcd:
   local:
     imageRepository: "quay.io/coreos"


### PR DESCRIPTION
The "ClusterConfiguration.DNS.Type" field has been removed 

Ref : 
https://kubernetes.io/docs/reference/config-api/kubeadm-config.v1beta3/